### PR TITLE
Create redcap tables and configure redcap_base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # redcap-docker-compose
 
 ![Docker Compose][docker-compose-logo]
-![REDCap][redcap-logo] 
+![REDCap][redcap-logo]
 
 This docker-compose script builds a working php-mysql environment designed for REDCap.
-  This is one of the easiest ways to create a local development instance of REDCap on your computer or test server
+  This is one of the easiest ways to create a local development instance of REDCap on your computer or test server.
 
 ## About
 This docker-compose will build multiple servers as part of a docker group to host REDCap on your local computer/server.
@@ -14,15 +14,15 @@ It consists of:
  * The official PhpMyAdmin web-based mysql tool for managing the database.
  * A basic alpine-based cron image (for running the REDCap cron and handling log rotation)
  * A basic alpine-based MailHop image (for capturing outbound emails from REDCap for your review)
- * A basic alpine-based setup image to create your first REDCap webroot and database.php
+ * A basic alpine-based setup image to create your first REDCap webroot, database.php, and populate the REDCap tables.
 
 The advantage of this docker-based method is you can easily upgrade database versions, php versions, and see how
-these changes might affect your projects or custom code
+these changes might affect your projects or custom code.
 
 ## Configuration
 The services are mainly configured through a `.env` environment file.  Additional customization can be done my modifying
 the files in the `override-*` directories.
-  
+
 See the [documentaton](documentation/README.md) for more information on getting started!
 
 ## Updates
@@ -31,11 +31,11 @@ See the [documentaton](documentation/README.md) for more information on getting 
 * 2018-08-01  Major refactoring into docker-compose 3
 
 ## License
-Copyright (c) 2016 Andrew Martin  
+Copyright (c) 2016 Andrew Martin
 Licensed under the MIT license.
 
 ## Contributing
-Please make pull requests to extent the functionality and documenatation
+Please make pull requests to extend the functionality and documentation
 
 [redcap-logo]: documentation/redcap-logo-large.png "REDCap"
 [docker-compose-logo]: documentation/docker-compose.png "Docker Compose"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It consists of:
  * The official PhpMyAdmin web-based mysql tool for managing the database.
  * A basic alpine-based cron image (for running the REDCap cron and handling log rotation)
  * A basic alpine-based MailHop image (for capturing outbound emails from REDCap for your review)
- * A basic alpine-based setup image to create your first REDCap webroot, database.php, and populate the REDCap tables.
+ * A basic alpine-based setup image to create your first REDCap webroot, database.php, populate the REDCap tables and configure REDCap.
 
 The advantage of this docker-based method is you can easily upgrade database versions, php versions, and see how
 these changes might affect your projects or custom code.

--- a/docker-setup/Dockerfile
+++ b/docker-setup/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:latest
 MAINTAINER andy123@stanford.edu
 
 RUN apk add --no-cache unzip \
+  mysql-client \
   && rm -rf /tmp/*
 
 COPY entrypoint.sh /

--- a/docker-setup/entrypoint.sh
+++ b/docker-setup/entrypoint.sh
@@ -43,6 +43,21 @@ create_redcap_tables() {
     echo "REDCap tables created"
 }
 
+set_redcap_config() {
+    DATABASE_HOSTNAME=$1
+    DATABASE_NAME=$2
+    DATABASE_USER=$3
+    DATABASE_PASSWORD=$4
+    info_text=$5
+    field_name=$6
+    value=$7
+    echo "set_redcap_config: $info_text"
+
+    CONNECTION="-h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME"
+    mysql $CONNECTION -e "UPDATE $DATABASE_NAME.redcap_config SET value = '$value' WHERE field_name = '$field_name';"
+}
+
+
 
 if [[ "$PARSE_ZIP_INSTALLER" = true ]] || [[ "$FORCE_RUN" = true ]]; then
 
@@ -122,6 +137,9 @@ if [[ "$PARSE_ZIP_INSTALLER" = true ]] || [[ "$FORCE_RUN" = true ]]; then
                             fi
                             # populate database
                             create_redcap_tables ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${WEBROOT} ${version} db
+                            # configure REDCAP
+                            MYSQL_HOSTNAME=db
+                            set_redcap_config ${MYSQL_HOSTNAME} ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} "Setting redcap_base_url..." redcap_base_url "http://localhost/"
                         fi
 
                         echo "Cleaning up ${dir}"

--- a/docker-setup/entrypoint.sh
+++ b/docker-setup/entrypoint.sh
@@ -7,56 +7,57 @@ TEMP="/tmp"
 WEBROOT="/webroot"
 extWEBROOT="${WEBROOT_DIR}"
 
-create_redcap_tables() {
-    REQUIRED_PARAMETER_COUNT=6
-    if [ $# != $REQUIRED_PARAMETER_COUNT ]; then
-        echo "${FUNCNAME[0]} Creates a MySQL database, a DB user with access to the DB, and sets user's password."
-        echo "${FUNCNAME[0]} requires these $REQUIRED_PARAMETER_COUNT parameters in this order:"
-        echo "DATABASE_NAME        Name of the database to create"
-        echo "DATABASE_USER        Database user who will have access to DATABASE_NAME"
-        echo "DATABASE_PASSWORD    Password of DATABASE_USER"
-        echo "DEPLOY_DIR           The directory where the app is deployed"
-        echo "VERSION              The version of the schema files to be loaded"
-        echo "DATABASE_HOSTNAME    Database host that houses the redcap DB"
-        return 1
-    else
-        DATABASE_NAME=$1
-        DATABASE_USER=$2
-        DATABASE_PASSWORD=$3
-        DEPLOY_DIR=$4
-        VERSION=$5
-        DATABASE_HOSTNAME=$6
-    fi
-
-
-    echo "Creating REDCap tables..."
-    SQL_DIR=$DEPLOY_DIR/redcap_v$VERSION/Resources/sql
-    mysql -h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME < $SQL_DIR/install.sql
-    mysql -h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME < $SQL_DIR/install_data.sql
-    mysql -h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME -e "UPDATE $DATABASE_NAME.redcap_config SET value = '$VERSION' WHERE field_name = 'redcap_version' "
-
-    files=$(ls -v $SQL_DIR/create_demo_db*.sql)
-    for i in $files; do
-        echo "Executing sql file $i"
-        mysql -h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME < $i
-    done
-    echo "REDCap tables created"
-}
-
 set_redcap_config() {
     DATABASE_HOSTNAME=$1
-    DATABASE_NAME=$2
-    DATABASE_USER=$3
-    DATABASE_PASSWORD=$4
+    DATABASE_USER=$2
+    DATABASE_PASSWORD=$3
+    DATABASE_NAME=$4
     info_text=$5
     field_name=$6
     value=$7
     echo "set_redcap_config: $info_text"
 
-    CONNECTION="-h$DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME"
+    CONNECTION="-h $DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME"
     mysql $CONNECTION -e "UPDATE $DATABASE_NAME.redcap_config SET value = '$value' WHERE field_name = '$field_name';"
 }
 
+create_redcap_tables() {
+    REQUIRED_PARAMETER_COUNT=6
+    if [ $# != $REQUIRED_PARAMETER_COUNT ]; then
+        echo "${FUNCNAME[0]} Creates a MySQL database, a DB user with access to the DB, and sets user's password."
+        echo "${FUNCNAME[0]} requires these $REQUIRED_PARAMETER_COUNT parameters in this order:"
+        echo "DATABASE_HOSTNAME    Database host that houses the redcap DB"
+        echo "DATABASE_USER        Database user who will have access to DATABASE_NAME"
+        echo "DATABASE_PASSWORD    Password of DATABASE_USER"
+        echo "DATABASE_NAME        Name of the database to create"
+        echo "DEPLOY_DIR           The directory where the app is deployed"
+        echo "VERSION              The version of the schema files to be loaded"
+        return 1
+    else
+        DATABASE_HOSTNAME=$1
+        DATABASE_USER=$2
+        DATABASE_PASSWORD=$3
+        DATABASE_NAME=$4
+        DEPLOY_DIR=$5
+        VERSION=$6
+    fi
+
+
+    echo "Creating REDCap tables..."
+    SQL_DIR=$DEPLOY_DIR/redcap_v$VERSION/Resources/sql
+    CONNECTION_PARMS="-h $DATABASE_HOSTNAME -u$DATABASE_USER -p$DATABASE_PASSWORD $DATABASE_NAME"
+    mysql $CONNECTION_PARMS < $SQL_DIR/install.sql
+    mysql $CONNECTION_PARMS < $SQL_DIR/install_data.sql
+    CONNECTION_VARS="$DATABASE_HOSTNAME $DATABASE_USER $DATABASE_PASSWORD $DATABASE_NAME"
+    set_redcap_config $CONNECTION_VARS "Setting redcap_version..." redcap_version $VERSION
+
+    files=$(ls -v $SQL_DIR/create_demo_db*.sql)
+    for i in $files; do
+        echo "Executing sql file $i"
+        mysql $CONNECTION_PARMS < $i
+    done
+    echo "REDCap tables created"
+}
 
 
 if [[ "$PARSE_ZIP_INSTALLER" = true ]] || [[ "$FORCE_RUN" = true ]]; then
@@ -136,10 +137,11 @@ if [[ "$PARSE_ZIP_INSTALLER" = true ]] || [[ "$FORCE_RUN" = true ]]; then
                                 echo "REDCap v${version} installed to ${extWEBROOT} and database.php file generated" > $file.log
                             fi
                             # populate database
-                            create_redcap_tables ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${WEBROOT} ${version} db
-                            # configure REDCAP
                             MYSQL_HOSTNAME=db
-                            set_redcap_config ${MYSQL_HOSTNAME} ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} "Setting redcap_base_url..." redcap_base_url "http://localhost/"
+                            MYSQL_CONNECTION_PARMS="${MYSQL_HOSTNAME} ${MYSQL_USER} ${MYSQL_PASSWORD} ${MYSQL_DATABASE}"
+                            create_redcap_tables ${MYSQL_CONNECTION_PARMS} ${WEBROOT} ${version}
+                            # configure REDCAP
+                            set_redcap_config ${MYSQL_CONNECTION_PARMS} "Setting redcap_base_url..." redcap_base_url "http://localhost/"
                         fi
 
                         echo "Cleaning up ${dir}"

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -34,24 +34,27 @@ a pull request if you do something interesting.
 1. Lastly, you will start-up the containers.  This can be done from the terminal/command line by navigating to the folder
    containing the `docker-compose.yml` file and running a docker-compose up command.
 
- 
+
 ## Installing REDCap
 
 There are two ways to get your new docker-compose REDCap environment running - I recommend using the startup assistant,
  but you can also choose the manual method if you want to learn more or have an existing environment you are porting
  over.
 
-### A) Startup Assistant
-There is an optional *startup assistant* that can help extract your first redcap install and configure your database.php
-file.
-1. Before you start up the containers the first time, download the `redcapx.x.x.zip` file from consortium into the
+### A) Setup Assistant
+There is an optional *setup assistant* that can help extract your first REDCap install, configure your database.php
+file, and populate your database tables.
+1. Before you start up the containers the first time, download the `redcapx.x.x.zip` file from the Consortium website into the
  `REDCAP-DOWNLOADS` directory.
-1. Then goto the terminal where this file is located and run:
+1. Then go to the root of this repository and run:
 ```bash
 redcap-docker-compose$ docker-compose up
 ```
 The first startup might take a while, so be patient.  Keep an eye on your `WEBROOT_DIR` and review the logs.  If all
-goes well, you should be able to skip to the [Configure REDCap](#configure-redcap) section.
+goes well, you should have a running REDCap.  To access this REDCap, direct your web browser to [http://localhost/]( http://localhost/).
+
+If you _don't_ see a running REDCap, review the manual steps below to figure out what step failed.
+
 
 ### B) Manual setup WEBROOT_DIR
 Alternately, you can manually add the contents of a redcap installer into your `WEBROOT_DIR` folder and then setup the
@@ -96,7 +99,7 @@ At this point, we assume that you have a running set of containers.  If you shou
 1. Open the installer at [http://localhost/install.php](http://localhost/install.php)
     * You can *IGNORE* the part about creating a new database user - you already have one as defined in the MYSQL_XXX
 variables in the `.env` file.
-    * IF YOU JUST GOTO h`ttp://localhost` you will likely see an error about 'wrong version' - you have to goto the `/install.php` first!
+    * IF YOU JUST GOTO `http://localhost` you will likely see an error about 'wrong version' - you have to goto the `/install.php` first!
 1. Copy the SQL to generate your redcap database and then execute it!  See [Connecting to the database](#connecting-to-the-database)
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -43,7 +43,7 @@ There are two ways to get your new docker-compose REDCap environment running - I
 
 ### A) Setup Assistant
 There is an optional *setup assistant* that can help extract your first REDCap install, configure your database.php
-file, and populate your database tables.
+file, populate your database tables and configure REDCap.
 1. Before you start up the containers the first time, download the `redcapx.x.x.zip` file from the Consortium website into the
  `REDCAP-DOWNLOADS` directory.
 1. Then go to the root of this repository and run:


### PR DESCRIPTION
Add functions create_redcap_tables and set_redcap_config to docker-setup/entrypoint. Use them to create the initial REDCap tables and configure REDCap. This new feature is reflected in the revisions to the READMEs.  I fixed some unrelated typos as well. 

Testing steps:
- [ ] take your composed environment down, erase any mysql volumes, erase the deployment state, build the setup image, bring the environment up and bring the `setup` container up. You can do all of that with this command:

```
docker-compose down -v && rm -f VOLUMES/www/database_*.php && docker-compose build setup && docker-compose up -d && docker-compose up setup
```
- [ ] Visit http://localhost to verify REDCap is up.
- [ ] Visit the control panel and confirm there are no complaints about the redcap_base_url.

