### PR TITLE
Feature/autogenerate table based users

### DIFF
--- a/rdc/redcap-overrides/web/webroot/REDCapInstaller.php
+++ b/rdc/redcap-overrides/web/webroot/REDCapInstaller.php
@@ -152,14 +152,15 @@ class REDCapInstaller {
 
                         if ($init_table) {
 
-                            $defaultUsers = $this->createDefaultUsersArray();
+                            $init_table_email = ($_POST['init-table-email']) ?: "you@example.org";
+                            $defaultUsers = $this->createDefaultUsersArray($init_table_email);
                             $users_added = "";
                             foreach($defaultUsers as $user) {
                                 $result = $this->createUser(...$user);
                                 $users_added .= $user[0] . "\n";
                             }
-
                             $this->successes[] = "Created users: $users_added";
+
                             // Turn on table-based auth
                             $this->db_query("UPDATE redcap_config SET value = 'table' WHERE field_name = 'auth_meth_global'");
                             // revoke site_admin's admin privs to avoid warning
@@ -594,6 +595,7 @@ color: #999;
         .bg-cardinal {background-color: #8c1515}
         .install-option {display:none;}
         .card-footer {display:none;}
+        .supplement-options {display:none;}
         </style>
             </head>
             <body>

--- a/rdc/redcap-overrides/web/webroot/redcap-setup.php
+++ b/rdc/redcap-overrides/web/webroot/redcap-setup.php
@@ -109,6 +109,14 @@ if ($RI->step == 1) {
                     </div>
                 </div>
 
+                Would you like to prepopulate with table-based users and activate table authentication?
+                    <div class="form-check">
+                        <label class="form-check-label">
+                            <input type="checkbox" value=1 class="form-check-input" name="init-table">
+                            Yes
+                        </label>
+                    </div>
+
             </div>
 
             <div class="card-footer">

--- a/rdc/redcap-overrides/web/webroot/redcap-setup.php
+++ b/rdc/redcap-overrides/web/webroot/redcap-setup.php
@@ -109,13 +109,53 @@ if ($RI->step == 1) {
                     </div>
                 </div>
 
-                Would you like to prepopulate with table-based users and activate table authentication?
+                <br>
+
+                <div id="supplement">
+                <h5>These quality of life items will be automatically applied to you REDCap instance after installation if you select them.</h5>
                     <div class="form-check">
                         <label class="form-check-label">
                             <input type="checkbox" value=1 class="form-check-input" name="init-table">
-                            Yes
+                            Prepopulate with table-based users and activate table authentication
                         </label>
+                        <div class="supplement-options form-group" id="init-table">
+                            <label class="form-check-label" for="init-table-email">
+                                Email address
+                            </label>
+                            <input type="email" class="supplement-option form-control" name="init-table-email" placeholder="you@example.org">
+                            <small class="form-text text-muted">This email will be set for each created user</small>
+
+                            <p>The following 5 users will be made:</p>
+                            <table class="table table-sm table-hover">
+                                <caption>All users will be initialized with the password "password".</caption>
+                                <tr>
+                                    <th>Username</th>
+                                    <th>Role</th>
+                                </tr>
+                                <tr>
+                                    <td>admin</td>
+                                    <td>admin/superuser</td>
+                                </tr>
+                                <tr>
+                                    <td>alice</td>
+                                    <td>account manager</td>
+                                </tr>
+                                <tr>
+                                    <td>bob</td>
+                                    <td>user</td>
+                                </tr>
+                                <tr>
+                                    <td>carol</td>
+                                    <td>user</td>
+                                </tr>
+                                <tr>
+                                    <td>dan</td>
+                                    <td>user</td>
+                                </tr>
+                            </table>
+                        </div>
                     </div>
+                </div>
 
             </div>
 
@@ -125,7 +165,7 @@ if ($RI->step == 1) {
                         class="input-group btn btn-lg btn-success initiate-installation text-center d-block">INSTALL
                     REDCAP
                 </button>
-                <small class="form-text text-muted text-center">Any existing files will be overwritten. This make time some time to
+                <small class="form-text text-muted text-center">Any existing files will be overwritten. This may time some time to
                     download and extract... Be patient!
                 </small>
             </div>
@@ -213,6 +253,20 @@ if ($RI->step == 1) {
             .select2({
                 'theme': 'bootstrap4'
             });
+
+
+        // Reveal additional config for supplemental options on click
+        // of supplemental option
+        $('#supplement input:not(".supplement-option")').bind('click', function() {
+            let option = $(this).prop("checked");
+            let name = $(this).prop('name');
+            let $supplementDiv = $('div#' + name);
+            $('div.supplement-options').hide();
+            if (option) {
+                $supplementDiv.fadeIn();
+            }
+
+        });
 
     });
 


### PR DESCRIPTION
This PR implements the option to autopopulate the database with 5 table-based users via the GUI. All user information is hardcoded aside from the option to set an email address for all 5 users. Usernames and their role/privilege-level are revealed upon activating the option:

![image](https://user-images.githubusercontent.com/20332546/73569259-0f134580-4438-11ea-8d2e-001aaa81e19d.png)

Following the advice of @pbchase, I also tried to craft this PR such that other QoL additions may be implemented in the same manner (i.e. under the `#supplement` div, with additional configurations/description living in a div with class `supplement-option` and an id matching the name property of the option to which it is associated).