### PR TITLE
Updates to add credentials folder and clean up REDCap cron

### DIFF
--- a/credentials/README.md
+++ b/credentials/README.md
@@ -1,0 +1,2 @@
+# Credentials Folder
+I've used this to store Google Cloud API keys and other API keys that I want stored outside the webroot

--- a/rdc/.env-example
+++ b/rdc/.env-example
@@ -25,6 +25,11 @@ LOGS_DIR=../logs
 # WEBROOT_DIR=/Users/andy123/Desktop/redcap-local
 WEBROOT_DIR=../www
 
+# THIS IS WHERE YOUR CREDENTIALS ARE LOCATED (for outside APIs). SHOULD BE OUTSIDE WEBROOT
+# CAN MOVE IT TO A DIFFERENT LOCATION ON YOUR COMPUTER, SUCH AS:
+# WEBROOT_DIR=/Users/andy123/Desktop/credentials
+CREDENTIALS_DIR=../credentials
+
 # WILL REDCAP RUN AS THE DEFAULT WEB APP ON YOUR INSTANCE?  (e.g. 'http://localhost' vs. 'http://localhost/redcap')
 # TO HAVE REDCAP RUN AS THE DEFAULT APP (e.g. http://localhost) USE "/"
 # TO HAVE REDCAP RUN UNDER A FOLDER (e.g http://localhost/redcap/) USE "/redcap/"

--- a/rdc/docker-compose.yml
+++ b/rdc/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     volumes:
       - ${WEB_OVERRIDES}:/etc/container-config-override
       - ${WEBROOT_DIR}:/var/www/html
+      - ${CREDENTIALS_DIR}:/var/credentials
       - ${LOGS_DIR}:/var/log/apache2
     networks:
       - redcap_network

--- a/rdc/docker-cron/Dockerfile
+++ b/rdc/docker-cron/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.8
 
 RUN apk add --no-cache tzdata logrotate
-ENV TZ America/Los_Angeles
 
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/rdc/docker-cron/entrypoint.sh
+++ b/rdc/docker-cron/entrypoint.sh
@@ -12,11 +12,19 @@ if [ ! -z "$APACHE_RUN_USER_ID" ]; then
     fi
 fi
 
-# ADD REDCap CRON ENTRIES
-echo "*   * * * *   wget web${REDCAP_WEBROOT_PATH}cron.php --spider >/dev/null 2>&1" >> /var/spool/cron/crontabs/root
+if grep -Fq "cron.php" /var/spool/cron/crontabs/root
+then
+    # code if found
+	echo "Found cron.php entry already exists"
+else
+	# ADD REDCap CRON ENTRIES
+	echo "*   * * * *   wget web${REDCAP_WEBROOT_PATH}cron.php --spider >/dev/null 2>&1" >> /var/spool/cron/crontabs/root
 
-# Add logrotate scripts
-echo "*/5 * * * *   /usr/sbin/logrotate /etc/logrotate.conf"    >> /var/spool/cron/crontabs/root
+	# Add logrotate scripts
+	echo "*/5 * * * *   /usr/sbin/logrotate /etc/logrotate.conf"    >> /var/spool/cron/crontabs/root
+	echo "Added cron entry"
+fi
+
 # Log Rotate throws an error if this file doesn't exist
 touch /var/log/messages
 


### PR DESCRIPTION
Noticed after multiple restarts that the crontab file ends up with multiple copies of the REDCap cron, which causes several copies to run simultaneously. Also had issues with the Timezone on the cron container not matching the one on web and DB.

Another use case I had was storing API credentials and wanted them outside the webroot, so added a new volume to store them.