### PR TITLE
remove libapache2-mod-shib2

### DIFF
--- a/rdc/docker-web/Dockerfile
+++ b/rdc/docker-web/Dockerfile
@@ -7,7 +7,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq && \
     apt-get -yq --no-install-recommends install \
-    libapache2-mod-shib2 \
     msmtp-mta \
     ca-certificates \
     git \


### PR DESCRIPTION
hi @123andy: 
I don't have a good explanation but build fails for me on Docker 3.5.2 will all the same defaults as in your `.env-example`
If I remove libapache2-mod-shib2 it works fine
[maybe related?](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=909558)

btw really like this rdc that you created I find it very helpful!