### PR TITLE
Updated the .zip upload installer size to accept larger files

### DIFF
--- a/rdc/redcap-overrides/web/webroot/REDCapInstaller.php
+++ b/rdc/redcap-overrides/web/webroot/REDCapInstaller.php
@@ -462,7 +462,7 @@ class REDCapInstaller {
             }
 
             // As of 8.7.3, size is 26475806
-            if ($_FILES[$field_name]['size'] > 50000000) {
+            if ($_FILES[$field_name]['size'] > 70000000) {
                 throw new RuntimeException('Exceeded filesize limit.');
             }
 


### PR DESCRIPTION
Increase the size of the .zip installer uploads since the sizes starting with version 11.x are well above 50mb.